### PR TITLE
Upgrade webnative 0.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install
 To run the example locally:
 
 ```
-npm start
+npm run dev
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Built by FISSION](https://img.shields.io/badge/⌘-Built_by_FISSION-purple.svg)](https://fission.codes)
-[![Built by FISSION](https://img.shields.io/badge/webnative-v0.35.2-purple.svg )](https://github.com/fission-suite/webnative)
+[![Built by FISSION](https://img.shields.io/badge/webnative-v0.36.1-purple.svg )](https://github.com/fission-suite/webnative)
 [![Discord](https://img.shields.io/discord/478735028319158273.svg)](https://discord.gg/zAQBDEq)
 [![Discourse](https://img.shields.io/discourse/https/talk.fission.codes/topics)](https://talk.fission.codes)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "tachyons": "^4.12.0",
-        "webnative": "^0.35.2"
+        "webnative": "^0.36.1"
       },
       "devDependencies": {
         "css-loader": "^4.3.0",
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@ipld/dag-pb/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -142,9 +142,9 @@
       "dev": true
     },
     "node_modules/@libp2p/interface-connection": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.7.tgz",
-      "integrity": "sha512-MBDrGlrSO1nL1DqqjNQzZSjcY2tobo6BOo9DxCFbaESiK7u1YLBNo9Amd0o5bPpFjez+O/VSasz9x3SQpHU1qQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
+      "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@libp2p/interface-connection/node_modules/@libp2p/interface-peer-id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.0.tgz",
-      "integrity": "sha512-TZmJy/tfWNvX/n1TWby6V+LP9Pg3ZYJbSkqQfnqp/hCCN3Xhd2KrDTm4LWq5MMunr4Xk9xLUJdK41W2wUF7OQw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
       "dependencies": {
         "multiformats": "^11.0.0"
       },
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@libp2p/interface-connection/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@libp2p/interface-keys": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.6.tgz",
-      "integrity": "sha512-cYe8DyKONA4TFdjEnPTPSWRntBH5+MMzivjtduVQukv7aO6PpihBF4PixzhKds+ciR2TMIkGXPsDaehmmU0Mqw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.7.tgz",
+      "integrity": "sha512-DRMPY9LfcnGJKrjaqIkY62U3fW2dya3VLy4x986ExtMrGn4kxIHeQ1IKk8/Vs9CJHTKmXEMID4of1Cjnw4aJpA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@libp2p/interface-peer-info": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.7.tgz",
-      "integrity": "sha512-aVI4ii1DFBF1dmQM5uemtO/qxNedCREzBtt2kAQtusN55BKT9GOlBSme+xTYpXw63iDrbtLXgJH+gNPoPkwJeQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
+      "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
       "dependencies": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@multiformats/multiaddr": "^11.0.0"
@@ -225,9 +225,9 @@
       }
     },
     "node_modules/@libp2p/interface-peer-info/node_modules/@libp2p/interface-peer-id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.0.tgz",
-      "integrity": "sha512-TZmJy/tfWNvX/n1TWby6V+LP9Pg3ZYJbSkqQfnqp/hCCN3Xhd2KrDTm4LWq5MMunr4Xk9xLUJdK41W2wUF7OQw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
       "dependencies": {
         "multiformats": "^11.0.0"
       },
@@ -237,18 +237,18 @@
       }
     },
     "node_modules/@libp2p/interface-peer-info/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/interface-pubsub": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.5.tgz",
-      "integrity": "sha512-+DsqrkDeYBuokMCuqLvlsdq4D/Tcs9bwSHeNUw1V88ffZE+pqmMIYntyIpFoI4SCLOxqB8U1B5yAlF/OBuJFSw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
+      "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
       "dependencies": {
         "@libp2p/interface-connection": "^3.0.0",
         "@libp2p/interface-peer-id": "^2.0.0",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@libp2p/interface-pubsub/node_modules/@libp2p/interface-peer-id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.0.tgz",
-      "integrity": "sha512-TZmJy/tfWNvX/n1TWby6V+LP9Pg3ZYJbSkqQfnqp/hCCN3Xhd2KrDTm4LWq5MMunr4Xk9xLUJdK41W2wUF7OQw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
       "dependencies": {
         "multiformats": "^11.0.0"
       },
@@ -274,18 +274,18 @@
       }
     },
     "node_modules/@libp2p/interface-pubsub/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@libp2p/interfaces": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.2.0.tgz",
-      "integrity": "sha512-lIVeMMv/TGcN4k5qfe1ZMwUvZTwWqLs7atxuoNdZ7lEPye94XNuHQj2WXoF9nEELkGKevpUJs/OB+gldl9MuFA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
+      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -307,9 +307,9 @@
       }
     },
     "node_modules/@libp2p/logger/node_modules/@libp2p/interface-peer-id": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.0.tgz",
-      "integrity": "sha512-TZmJy/tfWNvX/n1TWby6V+LP9Pg3ZYJbSkqQfnqp/hCCN3Xhd2KrDTm4LWq5MMunr4Xk9xLUJdK41W2wUF7OQw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
       "dependencies": {
         "multiformats": "^11.0.0"
       },
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/@libp2p/logger/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -355,18 +355,18 @@
       }
     },
     "node_modules/@libp2p/peer-id/node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.5.tgz",
-      "integrity": "sha512-sFppiscvhExFbSUdYl/4wBBOb5IjhYVpuRMBb6RgVjq7qTVHQDQeX3CEjQGdyy7+8A/cixL+fQez4RI+hltkLQ==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.4.0.tgz",
+      "integrity": "sha512-rLIhSOCKQhm/fCjg+5tVM9xrtjbZjZKJg6bb65YbFsNoPSYhweEohXO8Pkg2xbRy3NqVEVkS+8DB/+VhNvjd5Q==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
@@ -381,9 +381,9 @@
       }
     },
     "node_modules/@multiformats/multiaddr/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1532,9 +1532,9 @@
       "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="
     },
     "node_modules/datastore-core": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.3.tgz",
-      "integrity": "sha512-x1cAYGXnJQRDbUYF7pUBpx4bN+UP+8MOk66A30G70pVVnIG9TbkEAiapYUrwZGFdJnpZnb3HeS5Q13rsUNxIJQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.4.tgz",
+      "integrity": "sha512-oBA6a024NFXJOTu+w9nLAimfy4wCYUhdE/5XQGtdKt1BmCVtPYW10GORvVT3pdZBcse6k/mVcBl+hjkXIlm65A==",
       "dependencies": {
         "@libp2p/logger": "^2.0.0",
         "err-code": "^3.0.1",
@@ -1591,9 +1591,9 @@
       }
     },
     "node_modules/datastore-core/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -2496,9 +2496,9 @@
       }
     },
     "node_modules/interface-datastore": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.3.tgz",
-      "integrity": "sha512-6zUypd1LM2Rl8o58RgJ7stLHgqx5+9t0+XkUVAvjd3KkWCNKBknD7G+Zar5jpUGClS+IINRPTjH/8Xnc2HB39A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
       "dependencies": {
         "interface-store": "^3.0.0",
         "nanoid": "^4.0.0",
@@ -2510,9 +2510,9 @@
       }
     },
     "node_modules/interface-datastore/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -2531,9 +2531,9 @@
       }
     },
     "node_modules/interface-store": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.3.tgz",
-      "integrity": "sha512-FihzZamIkSPHIFw7xZAvZ77DEOSTvHt/t3HvIG7pm8lmqDIUh8/PgDsez/4Aa2091bT0sqK4tTFBcKF9TOGhtQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/ipfs-repo-migrations/node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -2692,9 +2692,9 @@
       }
     },
     "node_modules/ipfs-repo/node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -3658,9 +3658,9 @@
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-      "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.0.tgz",
+      "integrity": "sha512-s0y6Le9QYGELLzNpFIt6h8B2DHTVUDLStvxtvRMSKNKeuNVVWby2dZ+pIJpW4/pWr5a3s8W85wBNtc0ZA+lzCg==",
       "engines": {
         "node": ">=14.16"
       },
@@ -3858,9 +3858,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.1.tgz",
+      "integrity": "sha512-L3pCItypTnPK27+CS8nuhZMYtsY+i8dqdq2vZsYHlG17CnWp1DWPQ/sos0vOKrj1fHEAzo3GBqSHLaeZyKUCDA==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -4766,9 +4766,9 @@
       }
     },
     "node_modules/uint8arraylist/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+      "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -4800,9 +4800,9 @@
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.16.0.tgz",
+      "integrity": "sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -4921,9 +4921,9 @@
       }
     },
     "node_modules/webnative": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.2.tgz",
-      "integrity": "sha512-2TIK8Amt2M0STz3DFpxSgbujzhHjrwqaDgyTvIghzg6qGW9eHS73KwAC4ErjshFNlOPT7w6z1mVoIB9x3AUSJA==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.1.tgz",
+      "integrity": "sha512-ynBggqaQq3NFNkpyXMO+tpGHVZbE3clHTAQz6F2Zo8P8cTBacy6g5LDJHB1uKwUUvxQ43BkI/1oAyFl7w/1knQ==",
       "dependencies": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",
@@ -5401,9 +5401,9 @@
       },
       "dependencies": {
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         }
       }
     },
@@ -5416,9 +5416,9 @@
       },
       "dependencies": {
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         }
       }
     },
@@ -5478,9 +5478,9 @@
       "dev": true
     },
     "@libp2p/interface-connection": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.7.tgz",
-      "integrity": "sha512-MBDrGlrSO1nL1DqqjNQzZSjcY2tobo6BOo9DxCFbaESiK7u1YLBNo9Amd0o5bPpFjez+O/VSasz9x3SQpHU1qQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.0.8.tgz",
+      "integrity": "sha512-JiI9xVPkiSgW9hkvHWA4e599OLPNSACrpgtx6UffHG9N+Jpt0IOmM4iLic8bSIYkZJBOQFG1Sv/gVNB98Uq0Nw==",
       "requires": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@libp2p/interfaces": "^3.0.0",
@@ -5490,17 +5490,17 @@
       },
       "dependencies": {
         "@libp2p/interface-peer-id": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.0.tgz",
-          "integrity": "sha512-TZmJy/tfWNvX/n1TWby6V+LP9Pg3ZYJbSkqQfnqp/hCCN3Xhd2KrDTm4LWq5MMunr4Xk9xLUJdK41W2wUF7OQw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+          "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
           "requires": {
             "multiformats": "^11.0.0"
           }
         },
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         }
       }
     },
@@ -5513,9 +5513,9 @@
       }
     },
     "@libp2p/interface-keys": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.6.tgz",
-      "integrity": "sha512-cYe8DyKONA4TFdjEnPTPSWRntBH5+MMzivjtduVQukv7aO6PpihBF4PixzhKds+ciR2TMIkGXPsDaehmmU0Mqw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-keys/-/interface-keys-1.0.7.tgz",
+      "integrity": "sha512-DRMPY9LfcnGJKrjaqIkY62U3fW2dya3VLy4x986ExtMrGn4kxIHeQ1IKk8/Vs9CJHTKmXEMID4of1Cjnw4aJpA=="
     },
     "@libp2p/interface-peer-id": {
       "version": "1.1.2",
@@ -5526,33 +5526,33 @@
       }
     },
     "@libp2p/interface-peer-info": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.7.tgz",
-      "integrity": "sha512-aVI4ii1DFBF1dmQM5uemtO/qxNedCREzBtt2kAQtusN55BKT9GOlBSme+xTYpXw63iDrbtLXgJH+gNPoPkwJeQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-info/-/interface-peer-info-1.0.8.tgz",
+      "integrity": "sha512-LRvZt/9bZFYW7seAwuSg2hZuPl+FRTAsij5HtyvVwmpfVxipm6yQrKjQ+LiK/SZhIDVsSJ+UjF0mluJj+jeAzQ==",
       "requires": {
         "@libp2p/interface-peer-id": "^2.0.0",
         "@multiformats/multiaddr": "^11.0.0"
       },
       "dependencies": {
         "@libp2p/interface-peer-id": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.0.tgz",
-          "integrity": "sha512-TZmJy/tfWNvX/n1TWby6V+LP9Pg3ZYJbSkqQfnqp/hCCN3Xhd2KrDTm4LWq5MMunr4Xk9xLUJdK41W2wUF7OQw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+          "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
           "requires": {
             "multiformats": "^11.0.0"
           }
         },
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         }
       }
     },
     "@libp2p/interface-pubsub": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.5.tgz",
-      "integrity": "sha512-+DsqrkDeYBuokMCuqLvlsdq4D/Tcs9bwSHeNUw1V88ffZE+pqmMIYntyIpFoI4SCLOxqB8U1B5yAlF/OBuJFSw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-3.0.6.tgz",
+      "integrity": "sha512-c1aVHAhxmEh9IpLBgJyCsMscVDl7YUeP1Iq6ILEQoWiPJhNpQqdfmqyk7ZfrzuBU19VFe1EqH0bLuLDbtfysTQ==",
       "requires": {
         "@libp2p/interface-connection": "^3.0.0",
         "@libp2p/interface-peer-id": "^2.0.0",
@@ -5562,24 +5562,24 @@
       },
       "dependencies": {
         "@libp2p/interface-peer-id": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.0.tgz",
-          "integrity": "sha512-TZmJy/tfWNvX/n1TWby6V+LP9Pg3ZYJbSkqQfnqp/hCCN3Xhd2KrDTm4LWq5MMunr4Xk9xLUJdK41W2wUF7OQw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+          "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
           "requires": {
             "multiformats": "^11.0.0"
           }
         },
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         }
       }
     },
     "@libp2p/interfaces": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.2.0.tgz",
-      "integrity": "sha512-lIVeMMv/TGcN4k5qfe1ZMwUvZTwWqLs7atxuoNdZ7lEPye94XNuHQj2WXoF9nEELkGKevpUJs/OB+gldl9MuFA=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
+      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg=="
     },
     "@libp2p/logger": {
       "version": "2.0.5",
@@ -5593,17 +5593,17 @@
       },
       "dependencies": {
         "@libp2p/interface-peer-id": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.0.tgz",
-          "integrity": "sha512-TZmJy/tfWNvX/n1TWby6V+LP9Pg3ZYJbSkqQfnqp/hCCN3Xhd2KrDTm4LWq5MMunr4Xk9xLUJdK41W2wUF7OQw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
+          "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
           "requires": {
             "multiformats": "^11.0.0"
           }
         },
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         }
       }
     },
@@ -5627,18 +5627,18 @@
           },
           "dependencies": {
             "multiformats": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-              "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+              "version": "11.0.1",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+              "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
             }
           }
         }
       }
     },
     "@multiformats/multiaddr": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.1.5.tgz",
-      "integrity": "sha512-sFppiscvhExFbSUdYl/4wBBOb5IjhYVpuRMBb6RgVjq7qTVHQDQeX3CEjQGdyy7+8A/cixL+fQez4RI+hltkLQ==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-11.4.0.tgz",
+      "integrity": "sha512-rLIhSOCKQhm/fCjg+5tVM9xrtjbZjZKJg6bb65YbFsNoPSYhweEohXO8Pkg2xbRy3NqVEVkS+8DB/+VhNvjd5Q==",
       "requires": {
         "@chainsafe/is-ip": "^2.0.1",
         "dns-over-http-resolver": "^2.1.0",
@@ -5649,9 +5649,9 @@
       },
       "dependencies": {
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         },
         "uint8arrays": {
           "version": "4.0.3",
@@ -6587,9 +6587,9 @@
       "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="
     },
     "datastore-core": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.3.tgz",
-      "integrity": "sha512-x1cAYGXnJQRDbUYF7pUBpx4bN+UP+8MOk66A30G70pVVnIG9TbkEAiapYUrwZGFdJnpZnb3HeS5Q13rsUNxIJQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-8.0.4.tgz",
+      "integrity": "sha512-oBA6a024NFXJOTu+w9nLAimfy4wCYUhdE/5XQGtdKt1BmCVtPYW10GORvVT3pdZBcse6k/mVcBl+hjkXIlm65A==",
       "requires": {
         "@libp2p/logger": "^2.0.0",
         "err-code": "^3.0.1",
@@ -6626,9 +6626,9 @@
           "integrity": "sha512-lN3diSTomOvYBk2K0LHAgrQ52DlQfvq8tH/+HLAFpX8Q3JwBkr/BPJEi3Z3Lf8jMmN1KOCBXvt5sXa3eW9vUmg=="
         },
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         },
         "uint8arrays": {
           "version": "4.0.3",
@@ -7321,9 +7321,9 @@
       }
     },
     "interface-datastore": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.3.tgz",
-      "integrity": "sha512-6zUypd1LM2Rl8o58RgJ7stLHgqx5+9t0+XkUVAvjd3KkWCNKBknD7G+Zar5jpUGClS+IINRPTjH/8Xnc2HB39A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
+      "integrity": "sha512-Q8LZS/jfFFHz6XyZazLTAc078SSCoa27ZPBOfobWdpDiFO7FqPA2yskitUJIhaCgxNK8C+/lMBUTBNfVIDvLiw==",
       "requires": {
         "interface-store": "^3.0.0",
         "nanoid": "^4.0.0",
@@ -7331,9 +7331,9 @@
       },
       "dependencies": {
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         },
         "uint8arrays": {
           "version": "4.0.3",
@@ -7346,9 +7346,9 @@
       }
     },
     "interface-store": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.3.tgz",
-      "integrity": "sha512-FihzZamIkSPHIFw7xZAvZ77DEOSTvHt/t3HvIG7pm8lmqDIUh8/PgDsez/4Aa2091bT0sqK4tTFBcKF9TOGhtQ=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.4.tgz",
+      "integrity": "sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ=="
     },
     "interpret": {
       "version": "2.2.0",
@@ -7432,9 +7432,9 @@
           },
           "dependencies": {
             "multiformats": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-              "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+              "version": "11.0.1",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+              "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
             }
           }
         }
@@ -7469,9 +7469,9 @@
           },
           "dependencies": {
             "multiformats": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-              "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+              "version": "11.0.1",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+              "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
             }
           }
         }
@@ -8155,9 +8155,9 @@
       }
     },
     "p-timeout": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.0.0.tgz",
-      "integrity": "sha512-5iS61MOdUMemWH9CORQRxVXTp9g5K8rPnI9uQpo97aWgsH3vVXKjkIhDi+OgIDmN3Ly9+AZ2fZV01Wut1yzfKA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.0.tgz",
+      "integrity": "sha512-s0y6Le9QYGELLzNpFIt6h8B2DHTVUDLStvxtvRMSKNKeuNVVWby2dZ+pIJpW4/pWr5a3s8W85wBNtc0ZA+lzCg=="
     },
     "p-try": {
       "version": "2.2.0",
@@ -8306,9 +8306,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.1.tgz",
+      "integrity": "sha512-L3pCItypTnPK27+CS8nuhZMYtsY+i8dqdq2vZsYHlG17CnWp1DWPQ/sos0vOKrj1fHEAzo3GBqSHLaeZyKUCDA==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -8967,9 +8967,9 @@
       },
       "dependencies": {
         "multiformats": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.1.tgz",
+          "integrity": "sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA=="
         },
         "uint8arrays": {
           "version": "4.0.3",
@@ -8997,9 +8997,9 @@
       }
     },
     "undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.16.0.tgz",
+      "integrity": "sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==",
       "requires": {
         "busboy": "^1.6.0"
       }
@@ -9086,9 +9086,9 @@
       }
     },
     "webnative": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.35.2.tgz",
-      "integrity": "sha512-2TIK8Amt2M0STz3DFpxSgbujzhHjrwqaDgyTvIghzg6qGW9eHS73KwAC4ErjshFNlOPT7w6z1mVoIB9x3AUSJA==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/webnative/-/webnative-0.36.1.tgz",
+      "integrity": "sha512-ynBggqaQq3NFNkpyXMO+tpGHVZbE3clHTAQz6F2Zo8P8cTBacy6g5LDJHB1uKwUUvxQ43BkI/1oAyFl7w/1knQ==",
       "requires": {
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-pb": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "tachyons": "^4.12.0",
-    "webnative": "^0.35.2"
+    "webnative": "^0.36.1"
   },
   "devDependencies": {
     "css-loader": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "webpack-dev-server": "^4.3.0"
   },
   "scripts": {
-    "start": "webpack serve",
+    "dev": "webpack serve",
     "build": "webpack && cp index.html add.wasm silicon-dinosaur.png favicon.svg dist/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
# Description

This PR upgrades the app to use Webnative at `v0.36.1`. It also updates the local dev script from `npm start` to `npm run dev`.

## Link to issue

Closes #6 

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)